### PR TITLE
Configure the LSP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run Neovim tests
         run: |
-          nvim --headless -u NONE -c "lua dofile('runtests.lua')"
+          nvim -u .\runtests.lua --headless

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run Neovim tests
         run: |
-          nvim -u .\runtests.lua --headless
+          nvim -u runtests.lua --headless

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # mssql.nvim
+
 An SQL Server plugin for neovim. **Not ready yet!** If you are looking for something usable, come back later.
+
+todo: add docs for config values:
+
+- after initialise callback
+- tools_file
+- data_dir

--- a/lua/mssql/init.lua
+++ b/lua/mssql/init.lua
@@ -42,7 +42,6 @@ local function enable_lsp(data_dir, callback)
 		cmd = { ls },
 		filetypes = { "sql" },
 	}
-	print("enabling lsp")
 	vim.lsp.enable("mssql_ls")
 
 	if callback ~= nil then

--- a/lua/mssql/init.lua
+++ b/lua/mssql/init.lua
@@ -42,6 +42,7 @@ local function enable_lsp(data_dir, callback)
 		cmd = { ls },
 		filetypes = { "sql" },
 	}
+	print("enabling lsp")
 	vim.lsp.enable("mssql_ls")
 
 	if callback ~= nil then

--- a/lua/mssql/tools_downloader.lua
+++ b/lua/mssql/tools_downloader.lua
@@ -97,7 +97,6 @@ M.download_tools = function(url, data_folder, callback)
 			else
 				vim.notify("Downloaded successfully", vim.log.levels.INFO)
 				callback()
-				-- todo: attach to buffer if we've opened an sql file in the time we were downloading
 			end
 		end,
 		stderr_buffered = true,

--- a/lua/mssql/utils.lua
+++ b/lua/mssql/utils.lua
@@ -1,0 +1,24 @@
+local function map(tbl, fn)
+	local result = {}
+	for i, v in ipairs(tbl) do
+		result[i] = fn(v)
+	end
+	return result
+end
+
+local function contains(tbl, element)
+	if not table then
+		return false
+	end
+	for _, v in pairs(tbl) do
+		if v == element then
+			return true
+		end
+	end
+	return false
+end
+
+return {
+	map = map,
+	contains = contains,
+}

--- a/runtests.lua
+++ b/runtests.lua
@@ -2,6 +2,7 @@ vim.opt.rtp:prepend(".")
 
 local test_files = {
 	"tests/download_spec.lua",
+	"tests/completion_spec.lua",
 }
 
 local has_failures = false
@@ -12,6 +13,7 @@ for _, file in ipairs(test_files) do
 	if not ok then
 		has_failures = true
 		io.stderr:write("Error in " .. file .. ":\n" .. tostring(err) .. "\n")
+		break
 	else
 		print("Passed: " .. file)
 	end

--- a/runtests.lua
+++ b/runtests.lua
@@ -1,4 +1,23 @@
-vim.opt.rtp:prepend(".")
+local get_plugin_root = function()
+	local current_file = debug.getinfo(1, "S").source:sub(2)
+	local abs_path = vim.fn.fnamemodify(current_file, ":p")
+	local current_dir = vim.fs.dirname(abs_path)
+
+	return vim.fs.find("mssql.nvim", {
+		upward = true,
+		path = current_dir,
+		type = "directory",
+	})[1]
+end
+
+-- Prepend plugin root to runtimepath
+vim.opt.rtp:prepend(get_plugin_root())
+-- Disable swap files to avoid test errors
+vim.opt.swapfile = false
+
+require("mssql").setup()
+
+dofile("tests/completion_spec.lua")
 
 local test_files = {
 	-- "tests/download_spec.lua",

--- a/runtests.lua
+++ b/runtests.lua
@@ -1,7 +1,7 @@
 vim.opt.rtp:prepend(".")
 
 local test_files = {
-	"tests/download_spec.lua",
+	-- "tests/download_spec.lua",
 	"tests/completion_spec.lua",
 }
 

--- a/test.ps1
+++ b/test.ps1
@@ -1,1 +1,1 @@
-nvim --headless -u NONE -c "lua dofile('runtests.lua')"
+nvim -u .\runtests.lua --headless

--- a/tests/completion.sql
+++ b/tests/completion.sql
@@ -1,0 +1,2 @@
+se * from TestTable
+

--- a/tests/completion_spec.lua
+++ b/tests/completion_spec.lua
@@ -23,21 +23,12 @@ end)
 vim.defer_fn(function()
 	assert(#vim.lsp.get_clients({ bufnr = 0 }) == 1, "No lsp clients attached")
 	print("Language server attached")
+	-- move to the end of the "SE" in SELECT
+	vim.api.nvim_win_set_cursor(0, { 1, 2 })
+	get_completion_items(function(items)
+		assert(#items > 0, "Neovim didn't provide any completion items")
+		assert(utils.contains(items, "SELECT"))
+		print("SELECT was present!")
+		-- vim.cmd("qa!")
+	end)
 end, 3000)
-
--- -- move to the end of the "SE" in SELECT
--- vim.api.nvim_win_set_cursor(0, { 1, 2 })
---
--- local completed = false
--- local completion_items
--- get_completion_items(function(items)
--- 	completion_items = items
--- 	completed = true
--- end)
---
--- vim.wait(3000, function()
--- 	return completed
--- end, 100)
---
--- assert(completed and completion_items and #completion_items > 0, "Neovim didn't provide any completion items")
--- assert(utils.contains(completion_items, "SELECT"))

--- a/tests/completion_spec.lua
+++ b/tests/completion_spec.lua
@@ -1,6 +1,5 @@
 -- test comletions on a saved file
 local utils = require("mssql.utils")
-require("mssql").setup({})
 
 local function get_completion_items(callback)
 	-- Trigger <C-x><C-o> to invoke omnifunc
@@ -17,25 +16,28 @@ local function get_completion_items(callback)
 	end, 500)
 end
 
-vim.cmd("e tests/completion.sql")
--- wait for the lsp to load??
-vim.wait(2000)
-assert(#vim.lsp.get_clients({ bufnr = 0 }) == 1, "No lsp clients attached")
-print("Language server attached")
-
--- move to the end of the "SE" in SELECT
-vim.api.nvim_win_set_cursor(0, { 1, 2 })
-
-local completed = false
-local completion_items
-get_completion_items(function(items)
-	completion_items = items
-	completed = true
+vim.schedule(function()
+	vim.cmd("e tests/completion.sql")
 end)
 
-vim.wait(3000, function()
-	return completed
-end, 100)
+vim.defer_fn(function()
+	assert(#vim.lsp.get_clients({ bufnr = 0 }) == 1, "No lsp clients attached")
+	print("Language server attached")
+end, 3000)
 
-assert(completed and completion_items and #completion_items > 0, "Neovim didn't provide any completion items")
-assert(utils.contains(completion_items, "SELECT"))
+-- -- move to the end of the "SE" in SELECT
+-- vim.api.nvim_win_set_cursor(0, { 1, 2 })
+--
+-- local completed = false
+-- local completion_items
+-- get_completion_items(function(items)
+-- 	completion_items = items
+-- 	completed = true
+-- end)
+--
+-- vim.wait(3000, function()
+-- 	return completed
+-- end, 100)
+--
+-- assert(completed and completion_items and #completion_items > 0, "Neovim didn't provide any completion items")
+-- assert(utils.contains(completion_items, "SELECT"))

--- a/tests/completion_spec.lua
+++ b/tests/completion_spec.lua
@@ -16,19 +16,23 @@ local function get_completion_items(callback)
 	end, 500)
 end
 
-vim.schedule(function()
-	vim.cmd("e tests/completion.sql")
-end)
+return {
+	run_test = function(callback)
+		vim.schedule(function()
+			vim.cmd("e tests/completion.sql")
+		end)
 
-vim.defer_fn(function()
-	assert(#vim.lsp.get_clients({ bufnr = 0 }) == 1, "No lsp clients attached")
+		vim.defer_fn(function()
+			assert(#vim.lsp.get_clients({ bufnr = 0 }) == 1, "No lsp clients attached")
 
-	-- move to the end of the "SE" in SELECT
-	vim.api.nvim_win_set_cursor(0, { 1, 2 })
-	get_completion_items(function(items)
-		assert(#items > 0, "Neovim didn't provide any completion items")
-		assert(utils.contains(items, "SELECT"))
-		print("SELECT was present!")
-		vim.cmd("stopinsert")
-	end)
-end, 3000)
+			-- move to the end of the "SE" in SELECT
+			vim.api.nvim_win_set_cursor(0, { 1, 2 })
+			get_completion_items(function(items)
+				assert(#items > 0, "Neovim didn't provide any completion items")
+				assert(utils.contains(items, "SELECT"))
+				vim.cmd("stopinsert")
+				callback()
+			end)
+		end, 3000)
+	end,
+}

--- a/tests/completion_spec.lua
+++ b/tests/completion_spec.lua
@@ -22,13 +22,13 @@ end)
 
 vim.defer_fn(function()
 	assert(#vim.lsp.get_clients({ bufnr = 0 }) == 1, "No lsp clients attached")
-	print("Language server attached")
+
 	-- move to the end of the "SE" in SELECT
 	vim.api.nvim_win_set_cursor(0, { 1, 2 })
 	get_completion_items(function(items)
 		assert(#items > 0, "Neovim didn't provide any completion items")
 		assert(utils.contains(items, "SELECT"))
 		print("SELECT was present!")
-		-- vim.cmd("qa!")
+		vim.cmd("stopinsert")
 	end)
 end, 3000)

--- a/tests/completion_spec.lua
+++ b/tests/completion_spec.lua
@@ -1,30 +1,41 @@
 -- test comletions on a saved file
+local utils = require("mssql.utils")
+require("mssql").setup({})
+
+local function get_completion_items(callback)
+	-- Trigger <C-x><C-o> to invoke omnifunc
+	vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("i<C-x><C-o>", true, false, true), "n", true)
+
+	-- Completion results are async
+	vim.defer_fn(function()
+		local items = vim.fn.complete_info({ "items" }).items
+		items = items or {}
+
+		callback(utils.map(items, function(item)
+			return item.word or item.abbr
+		end))
+	end, 500)
+end
+
 vim.cmd("e tests/completion.sql")
-vim.api.nvim_win_set_cursor(0, { 1, 1 })
+-- wait for the lsp to load??
+vim.wait(2000)
+assert(#vim.lsp.get_clients({ bufnr = 0 }) == 1, "No lsp clients attached")
+print("Language server attached")
 
-local params = vim.lsp.util.make_position_params(0, "utf-8")
-local result
+-- move to the end of the "SE" in SELECT
+vim.api.nvim_win_set_cursor(0, { 1, 2 })
 
-vim.lsp.buf_request(0, "textDocument/completion", params, function(err, result, ctx, config)
-	if err then
-		result = { err = err }
-		return
-	end
-	if not result then
-		result = { err = "No LSP completion result" }
-		return
-	end
-
-	local items = vim.lsp.util.extract_completion_items(result)
-	result = { count = #items }
+local completed = false
+local completion_items
+get_completion_items(function(items)
+	completion_items = items
+	completed = true
 end)
 
-local ok, err = pcall(function()
-	vim.wait(10000, function()
-		return result ~= nil
-	end, 10)
-end)
+vim.wait(3000, function()
+	return completed
+end, 100)
 
-assert(ok, "setup() threw: " .. (err or ""))
-assert(not result.err, "Lsp threw:" .. result.err)
-assert(not result.count ~= 0, "0 completion items were returned")
+assert(completed and completion_items and #completion_items > 0, "Neovim didn't provide any completion items")
+assert(utils.contains(completion_items, "SELECT"))

--- a/tests/completion_spec.lua
+++ b/tests/completion_spec.lua
@@ -1,0 +1,30 @@
+-- test comletions on a saved file
+vim.cmd("e tests/completion.sql")
+vim.api.nvim_win_set_cursor(0, { 1, 1 })
+
+local params = vim.lsp.util.make_position_params(0, "utf-8")
+local result
+
+vim.lsp.buf_request(0, "textDocument/completion", params, function(err, result, ctx, config)
+	if err then
+		result = { err = err }
+		return
+	end
+	if not result then
+		result = { err = "No LSP completion result" }
+		return
+	end
+
+	local items = vim.lsp.util.extract_completion_items(result)
+	result = { count = #items }
+end)
+
+local ok, err = pcall(function()
+	vim.wait(10000, function()
+		return result ~= nil
+	end, 10)
+end)
+
+assert(ok, "setup() threw: " .. (err or ""))
+assert(not result.err, "Lsp threw:" .. result.err)
+assert(not result.count ~= 0, "0 completion items were returned")

--- a/tests/download_spec.lua
+++ b/tests/download_spec.lua
@@ -1,7 +1,5 @@
 local mssql = require("mssql")
 
-local download_finished = false
-
 function iif(cond, true_value, false_value)
 	if cond then
 		return true_value
@@ -16,23 +14,20 @@ local tools_file = iif(jit.os == "Windows", "MicrosoftSqlToolsServiceLayer.exe",
 vim.fn.delete(tools_folder, "rf")
 vim.fn.delete(vim.fs.joinpath(vim.fn.stdpath("data"), "mssql.nvim/config.json"))
 
-local ok, err = pcall(function()
-	mssql.setup(nil, function()
-		download_finished = true
-	end)
-	vim.wait(120000, function()
-		return download_finished
-	end, 1000)
+local download_finished = false
+
+mssql.setup(nil, function()
+	download_finished = true
+	local tools_file_exists = false
+	local f = io.open(vim.fs.joinpath(tools_folder, tools_file), "r")
+	if f then
+		f:close()
+		tools_file_exists = true
+	end
+
+	assert(tools_file_exists, "The sql server tools file does not exist among the downloads")
 end)
 
-assert(ok, "setup() threw: " .. (err or ""))
-assert(download_finished, "Download did not complete")
-
-local tools_file_exists = false
-local f = io.open(vim.fs.joinpath(tools_folder, tools_file), "r")
-if f then
-	f:close()
-	tools_file_exists = true
-end
-
-assert(tools_file_exists, "The sql server tools file does not exist among the downloads")
+vim.defer(function()
+	assert(download_finished, "Download did not complete")
+end, 120000)

--- a/tests/download_spec.lua
+++ b/tests/download_spec.lua
@@ -17,16 +17,22 @@ vim.fn.delete(tools_folder, "rf")
 vim.fn.delete(vim.fs.joinpath(vim.fn.stdpath("data"), "mssql.nvim/config.json"))
 
 local ok, err = pcall(function()
-	mssql.setup()
+	mssql.setup(nil, function()
+		download_finished = true
+	end)
 	vim.wait(120000, function()
-		local f = io.open(vim.fs.joinpath(tools_folder, tools_file), "r")
-		if f then
-			f:close()
-			download_finished = true
-		end
 		return download_finished
 	end, 1000)
 end)
 
 assert(ok, "setup() threw: " .. (err or ""))
 assert(download_finished, "Download did not complete")
+
+local tools_file_exists = false
+local f = io.open(vim.fs.joinpath(tools_folder, tools_file), "r")
+if f then
+	f:close()
+	tools_file_exists = true
+end
+
+assert(tools_file_exists, "The sql server tools file does not exist among the downloads")

--- a/tests/download_spec.lua
+++ b/tests/download_spec.lua
@@ -11,23 +11,30 @@ end
 local tools_folder = vim.fs.joinpath(vim.fn.stdpath("data"), "mssql.nvim/sqltools")
 local tools_file = iif(jit.os == "Windows", "MicrosoftSqlToolsServiceLayer.exe", "MicrosoftSqlToolsServiceLayer")
 
-vim.fn.delete(tools_folder, "rf")
-vim.fn.delete(vim.fs.joinpath(vim.fn.stdpath("data"), "mssql.nvim/config.json"))
-
-local download_finished = false
-
-mssql.setup(nil, function()
-	download_finished = true
-	local tools_file_exists = false
+local function tools_file_exists()
 	local f = io.open(vim.fs.joinpath(tools_folder, tools_file), "r")
 	if f then
 		f:close()
-		tools_file_exists = true
+		return true
 	end
+	return false
+end
 
-	assert(tools_file_exists, "The sql server tools file does not exist among the downloads")
-end)
+return {
+	run_test = function(callback)
+		vim.fn.delete(tools_folder, "rf")
+		vim.fn.delete(vim.fs.joinpath(vim.fn.stdpath("data"), "mssql.nvim/config.json"))
 
-vim.defer(function()
-	assert(download_finished, "Download did not complete")
-end, 120000)
+		local download_finished = false
+
+		mssql.setup(nil, function()
+			download_finished = true
+			assert(tools_file_exists(), "The sql server tools file does not exist among the downloads")
+			callback()
+		end)
+
+		vim.defer_fn(function()
+			assert(download_finished, "Download did not complete")
+		end, 120000)
+	end,
+}

--- a/tests/load-plugin.lua
+++ b/tests/load-plugin.lua
@@ -1,2 +1,17 @@
-vim.opt.rtp:prepend("C:/dev/mssql.nvim")
+local get_plugin_root = function()
+	local current_file = debug.getinfo(1, "S").source:sub(2)
+	local abs_path = vim.fn.fnamemodify(current_file, ":p")
+	local current_dir = vim.fs.dirname(abs_path)
+
+	return vim.fs.find("mssql.nvim", {
+		upward = true,
+		path = current_dir,
+		type = "directory",
+	})[1]
+end
+
+print(get_plugin_root())
+
+-- Prepend plugin root to runtimepath
+vim.opt.rtp:prepend(get_plugin_root())
 require("mssql").setup()

--- a/tests/load-plugin.lua
+++ b/tests/load-plugin.lua
@@ -17,4 +17,6 @@ vim.opt.swapfile = false
 
 require("mssql").setup()
 
-dofile("tests/completion_spec.lua")
+require("tests.completion_spec").run_test(function()
+	vim.cmd("qa!")
+end)

--- a/tests/load-plugin.lua
+++ b/tests/load-plugin.lua
@@ -10,8 +10,8 @@ local get_plugin_root = function()
 	})[1]
 end
 
-print(get_plugin_root())
-
 -- Prepend plugin root to runtimepath
 vim.opt.rtp:prepend(get_plugin_root())
 require("mssql").setup()
+
+dofile("tests/completion_spec.lua")

--- a/tests/load-plugin.lua
+++ b/tests/load-plugin.lua
@@ -1,3 +1,2 @@
--- for testing manually
-vim.opt.rtp:prepend(".")
-require("mssql")
+vim.opt.rtp:prepend("C:/dev/mssql.nvim")
+require("mssql").setup()

--- a/tests/load-plugin.lua
+++ b/tests/load-plugin.lua
@@ -15,7 +15,9 @@ vim.opt.rtp:prepend(get_plugin_root())
 -- Disable swap files to avoid test errors
 vim.opt.swapfile = false
 
-require("mssql").setup()
+require("mssql").setup({}, function()
+	require("tests.download_spec")
+end)
 
 require("tests.completion_spec").run_test(function()
 	vim.cmd("qa!")

--- a/tests/load-plugin.lua
+++ b/tests/load-plugin.lua
@@ -12,6 +12,9 @@ end
 
 -- Prepend plugin root to runtimepath
 vim.opt.rtp:prepend(get_plugin_root())
+-- Disable swap files to avoid test errors
+vim.opt.swapfile = false
+
 require("mssql").setup()
 
 dofile("tests/completion_spec.lua")

--- a/tests/load-plugin.lua
+++ b/tests/load-plugin.lua
@@ -15,10 +15,4 @@ vim.opt.rtp:prepend(get_plugin_root())
 -- Disable swap files to avoid test errors
 vim.opt.swapfile = false
 
-require("mssql").setup({}, function()
-	require("tests.download_spec")
-end)
-
-require("tests.completion_spec").run_test(function()
-	vim.cmd("qa!")
-end)
+require("mssql").setup()


### PR DESCRIPTION
- Add static LSP configuration (requires neovim 0.11)
- Add end to end test for autocompletion (only works on saved sql files at the moment)
- Make end to tests callback based (will switch to coroutines next)