### PR TITLE
Execute sql queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ end)
 | `tools_file`       | `string?` | Path to an existing [SQL tools service](https://github.com/microsoft/sqltoolsservice/releases) binary | `nil` (Binary auto downloaded to `data_dir`) |
 | `connections_file` | `string?` | Path to a json file containing connections (see below)                                                | `<data_dir>/connections.json`                |
 | `max_rows`         | `int?`    | Max rows to return for queries. Needed so that large results don't crash neovim.                      | `100`                                        |
+| `max_column_width` | int?      | If a result row has a field text length larger than this it will be truncated when displayed          | `100`                                        |
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ An SQL Server plugin for neovim. **Not ready yet!** If you are looking for somet
 - [x] Cross database query autocomplete
 - [x] Refresh intellisense cache
 - [x] Disconnect
-- [ ] Execute queries (first few lines only)
+- [ ] Execute queries (first 100 lines only)
+  - Each batch will open in a new buffer. Mark the buffer as a result buffer.
+  - Upon executing, delete all existing result buffers.
+- [ ] Key maps, docs, announce initial release
+- [ ] Execute queries with a configurable memory limit
 - [ ] Switch database
 - [ ] Auto format
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ require("mssql.nvim").setup()
 require("mssql.nvim").setup({
   data_dir = "/custom/path",
   tools_file = "/path/to/sqltools/executable",
-  connections_file = "/path/to/connections.json"
+  connections_file = "/path/to/connections.json",
+  max_rows = 100
 })
 
 -- With callback
@@ -55,6 +56,7 @@ end)
 | `data_dir`         | `string?` | Directory to store download tools and internal config options                                         | `vim.fn.stdpath("data")`                     |
 | `tools_file`       | `string?` | Path to an existing [SQL tools service](https://github.com/microsoft/sqltoolsservice/releases) binary | `nil` (Binary auto downloaded to `data_dir`) |
 | `connections_file` | `string?` | Path to a json file containing connections (see below)                                                | `<data_dir>/connections.json`                |
+| `max_rows`         | `int?`    | Max rows to return for queries. Needed so that large results don't crash neovim.                      | `100`                                        |
 
 ### Notes
 

--- a/lua/mssql/init.lua
+++ b/lua/mssql/init.lua
@@ -1,5 +1,6 @@
 local downloader = require("mssql.tools_downloader")
 local utils = require("mssql.utils")
+local query = require("mssql.query")
 
 local joinpath = vim.fs.joinpath
 
@@ -31,11 +32,42 @@ local function write_json_file(path, table)
 	end
 end
 
+local get_handlers = function()
+	return {
+		["connection/complete"] = function(_, result)
+			if result.errorMessage then
+				utils.log_error("Could not connect: " .. result.errorMessage)
+				return result,
+					vim.lsp.rpc.rpc_response_error(
+						vim.lsp.protocol.ErrorCodes.UnknownErrorCode,
+						result.errorMessage,
+						nil
+					)
+			else
+				utils.log_info("Connected")
+				return result, nil
+			end
+		end,
+
+		["textDocument/intelliSenseReady"] = function(err, result)
+			if err then
+				utils.log_error("Could not start intellisense: " .. vim.inspect(err))
+			else
+				utils.log_info("Intellisense ready")
+			end
+			return result, err
+		end,
+	}
+end
+
 local function enable_lsp(opts)
 	local default_path = joinpath(opts.data_dir, "sqltools/MicrosoftSqlToolsServiceLayer")
 	if jit.os == "Windows" then
 		default_path = default_path .. ".exe"
 	end
+
+	local handlers = get_handlers()
+	query.add_lsp_handlers(handlers, opts.max_rows)
 
 	vim.lsp.config["mssql_ls"] = {
 		cmd = {
@@ -44,32 +76,9 @@ local function enable_lsp(opts)
 			"--enable-sql-authentication-provider",
 		},
 		filetypes = { "sql" },
-		handlers = {
-			["connection/complete"] = function(_, result)
-				if result.errorMessage then
-					utils.log_error("Could not connect: " .. result.errorMessage)
-					return result,
-						vim.lsp.rpc.rpc_response_error(
-							vim.lsp.protocol.ErrorCodes.UnknownErrorCode,
-							result.errorMessage,
-							nil
-						)
-				else
-					utils.log_info("Connected")
-					return result, nil
-				end
-			end,
-
-			["textDocument/intelliSenseReady"] = function(err, result)
-				if err then
-					utils.log_error("Could not start intellisense: " .. vim.inspect(err))
-				else
-					utils.log_info("Intellisense ready")
-				end
-				return result, err
-			end,
-		},
+		handlers = handlers,
 	}
+
 	vim.lsp.enable("mssql_ls")
 end
 
@@ -101,6 +110,7 @@ local function setup_async(opts)
 		data_dir = data_dir,
 		tools_file = nil,
 		connections_file = joinpath(data_dir, "connections.json"),
+		max_rows = 100,
 	}
 	opts = vim.tbl_deep_extend("keep", opts or {}, default_opts)
 
@@ -153,7 +163,7 @@ end
 
 local connect_async = function(opts)
 	-- Check for an lsp client before prompting the user for connection
-	utils.get_lsp_client()
+	local client = utils.get_lsp_client()
 
 	local f = io.open(opts.connections_file, "r")
 	if not f then
@@ -178,15 +188,19 @@ local connect_async = function(opts)
 		},
 	}
 
-	local _, err = utils.lsp_request_async("connection/connect", connectParams)
+	local _, err = utils.lsp_request_async(client, "connection/connect", connectParams)
 	if err then
 		error("Could not connect: " .. err.message, 0)
 	end
 end
 
 local disconnect_async = function()
-	local result, err =
-		utils.lsp_request_async("connection/disconnect", { ownerUri = vim.uri_from_fname(vim.fn.expand("%:p")) })
+	local client = utils.get_lsp_client()
+	local result, err = utils.lsp_request_async(
+		client,
+		"connection/disconnect",
+		{ ownerUri = vim.uri_from_fname(vim.fn.expand("%:p")) }
+	)
 	if err then
 		error("Error disconnecting: " .. err.message, 0)
 	elseif not result then
@@ -232,6 +246,11 @@ return {
 	disconnect = function()
 		utils.try_resume(coroutine.create(function()
 			disconnect_async()
+		end))
+	end,
+	execute_query = function()
+		utils.try_resume(coroutine.create(function()
+			query.execute_async()
 		end))
 	end,
 }

--- a/lua/mssql/init.lua
+++ b/lua/mssql/init.lua
@@ -67,7 +67,7 @@ local function enable_lsp(opts)
 	end
 
 	local handlers = get_handlers()
-	query.add_lsp_handlers(handlers, opts.max_rows)
+	query.add_lsp_handlers(handlers, opts)
 
 	vim.lsp.config["mssql_ls"] = {
 		cmd = {
@@ -111,6 +111,7 @@ local function setup_async(opts)
 		tools_file = nil,
 		connections_file = joinpath(data_dir, "connections.json"),
 		max_rows = 100,
+		max_column_width = 100,
 	}
 	opts = vim.tbl_deep_extend("keep", opts or {}, default_opts)
 

--- a/lua/mssql/query.lua
+++ b/lua/mssql/query.lua
@@ -1,0 +1,80 @@
+local function truncate_values(table, limit)
+	for _, record in ipairs(table) do
+		for index, value in ipairs(record) do
+			local str = tostring(value)
+			if #str > limit then
+				str = str:sub(1, limit) .. "..."
+			end
+			record[index] = str
+		end
+	end
+end
+
+local function column_width(table, column_index)
+	return vim.iter(table)
+		:map(function(record)
+			return #record[column_index]
+		end)
+		:fold(0, math.max)
+end
+
+local function column_widths(table)
+	if not (table or table[1]) then
+		return {}
+	end
+
+	return vim.iter(ipairs(table[1]))
+		:map(function(column_index)
+			return column_width(table, column_index)
+		end)
+		:totable()
+end
+
+local function header_divider(widths)
+	if not widths then
+		return ""
+	end
+	local dashes = vim.iter(widths)
+		:map(function(w)
+			return string.rep("-", w + 2)
+		end)
+		:totable()
+	return "+" .. table.concat(dashes, "+") .. "+"
+end
+
+local function right_pad(str, len, char)
+	if #str >= len then
+		return str
+	end
+	return str .. string.rep(char, len - #str)
+end
+
+local function row_to_string(row, widths)
+	local padded_cells = vim.iter(ipairs(row))
+		:map(function(column_index, value)
+			return right_pad(value, widths[column_index], " ")
+		end)
+		:totable()
+	return "| " .. table.concat(padded_cells, " | ") .. " |"
+end
+
+local function query_results_to_string(query_results, max_width)
+	truncate_values(query_results, max_width)
+
+	if not (query_results or query_results[1]) then
+		return ""
+	end
+
+	local widths = column_widths(query_results)
+	local divider = header_divider(widths)
+
+	local lines = { divider, row_to_string(query_results[1], widths), divider }
+	for i = 2, #query_results do
+		table.insert(lines, row_to_string(query_results[i], widths))
+	end
+	table.insert(lines, divider)
+
+	return table.concat(lines, "\n")
+end
+
+print(query_results_to_string({ { "name", "age as of last year" }, { "Cassandra", 15 }, { "Bob", 30 } }, 100))

--- a/lua/mssql/query/init.lua
+++ b/lua/mssql/query/init.lua
@@ -1,0 +1,24 @@
+local function get_selected_text()
+	local mode = vim.api.nvim_get_mode().mode
+	if not (mode == "v" or mode == "V" or mode == "\22") then -- \22 is Ctrl-V (visual block)
+		local content = vim.api.nvim_buf_get_lines(0, 0, vim.api.nvim_buf_line_count(0), false)
+		return "not in visual mode" -- table.concat(content, "\n")
+	end
+
+	-- exit visual mode so the marks are applied
+	local esc = vim.api.nvim_replace_termcodes("<esc>", true, false, true)
+	vim.api.nvim_feedkeys(esc, "x", false)
+	-- -- utils.wait_for_schedule_async()
+
+	local start_pos = vim.fn.getpos("'<")
+	local end_pos = vim.fn.getpos("'>")
+	local lines = vim.fn.getregion(start_pos, end_pos, { mode = vim.fn.visualmode() })
+
+	return table.concat(lines, "\n")
+end
+
+return {
+	execute_async = function()
+		local query = get_selected_text()
+	end,
+}

--- a/lua/mssql/query/init.lua
+++ b/lua/mssql/query/init.lua
@@ -1,14 +1,15 @@
+local utils = require("mssql.utils")
+
 local function get_selected_text()
 	local mode = vim.api.nvim_get_mode().mode
 	if not (mode == "v" or mode == "V" or mode == "\22") then -- \22 is Ctrl-V (visual block)
 		local content = vim.api.nvim_buf_get_lines(0, 0, vim.api.nvim_buf_line_count(0), false)
-		return "not in visual mode" -- table.concat(content, "\n")
+		return table.concat(content, "\n")
 	end
 
 	-- exit visual mode so the marks are applied
 	local esc = vim.api.nvim_replace_termcodes("<esc>", true, false, true)
 	vim.api.nvim_feedkeys(esc, "x", false)
-	-- -- utils.wait_for_schedule_async()
 
 	local start_pos = vim.fn.getpos("'<")
 	local end_pos = vim.fn.getpos("'>")
@@ -17,8 +18,105 @@ local function get_selected_text()
 	return table.concat(lines, "\n")
 end
 
+local function show_result_set_async(column_info, subset_params)
+	local column_headers = vim.iter(column_info)
+		:map(function(i)
+			return i.columnName
+		end)
+		:totable()
+	local client = utils.get_lsp_client(subset_params.ownerUri)
+
+	local result, err = utils.lsp_request_async(client, "query/subset", subset_params)
+	if err then
+		error("Error getting rows: " .. vim.inspect(err), 0)
+	elseif not result then
+		error("Error getting rows", 0)
+	end
+
+	print(vim.inspect())
+
+	-- TODO: test the print results, see where the result rows are and pretty print them
+
+	local bufnr = vim.api.nvim_create_buf(true, false)
+	vim.api.nvim_buf_set_name(
+		bufnr,
+		"results " -- .. subset_params.batchIndex + 1 .. "-" .. subset_params.resultSetIndex + 1 .. ".md"
+	)
+
+	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {
+		"| name | age |",
+		"| ---- | --- |",
+		"| bob  | 64  |",
+		"| john | 65  |",
+	})
+	vim.api.nvim_set_option_value("buftype", "nofile", { buf = bufnr })
+	vim.api.nvim_set_option_value("bufhidden", "hide", { buf = bufnr })
+	vim.api.nvim_set_option_value("swapfile", false, { buf = bufnr })
+	vim.api.nvim_set_option_value("readonly", true, { buf = bufnr })
+	vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+
+	vim.api.nvim_set_current_buf(bufnr)
+end
+
+local function query_complete_async(max_rows, err, result)
+	if err then
+		error("Could not execute query: " .. vim.inspect(err), 0)
+	elseif not (result or result.batchSummaries) then
+		error("Could not execute query: no results returned" .. vim.inspect(err), 0)
+	end
+
+	for batch_index, batch_summary in ipairs(result.batchSummaries) do
+		if batch_summary.resultSetSummaries then
+			for result_set_index, result_set_summary in ipairs(batch_summary.resultSetSummaries) do
+				show_result_set_async(result_set_summary.columnInfo, {
+					ownerUri = result.ownerUri,
+					batchIndex = batch_index - 1,
+					resultSetIndex = result_set_index - 1,
+					rowsStartIndex = 0,
+					rowsCount = max_rows,
+				})
+			end
+		end
+	end
+end
+
 return {
 	execute_async = function()
+		local client = utils.get_lsp_client()
 		local query = get_selected_text()
+		local result, err = utils.lsp_request_async(
+			client,
+			"query/executeString",
+			{ query = query, ownerUri = vim.uri_from_fname(vim.fn.expand("%:p")) }
+		)
+
+		if err then
+			error("Error executing query: " .. err.message, 0)
+		elseif not result then
+			error("Could not execute query", 0)
+		else
+			utils.log_info("Executing...")
+		end
+
+		-- from here, the language server should send back some query/message evwnts then a final
+		-- query/complete event.
+	end,
+	add_lsp_handlers = function(handlers, max_rows)
+		handlers["query/complete"] = function(err, result)
+			utils.try_resume(coroutine.create(function()
+				query_complete_async(max_rows, err, result)
+			end))
+		end
+		handlers["query/message"] = function(_, result)
+			if not (result or result.message or result.message.message) then
+				return
+			end
+
+			if result.message.isError then
+				utils.log_error(result.message.message)
+			else
+				utils.log_info(result.message.message)
+			end
+		end
 	end,
 }

--- a/lua/mssql/query/init.lua
+++ b/lua/mssql/query/init.lua
@@ -19,8 +19,11 @@ local function get_selected_text()
 	return table.concat(lines, "\n")
 end
 
+local result_buffers = {}
+
 local function display_markdown(lines, buffer_name)
 	local bufnr = vim.api.nvim_create_buf(true, false)
+	table.insert(result_buffers, bufnr)
 	vim.api.nvim_buf_set_name(bufnr, buffer_name)
 	vim.bo[bufnr].filetype = "markdown"
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
@@ -69,6 +72,13 @@ local function query_complete_async(opts, err, result)
 		error("Could not execute query: " .. vim.inspect(err), 0)
 	elseif not (result or result.batchSummaries) then
 		error("Could not execute query: no results returned" .. vim.inspect(err), 0)
+	end
+
+	-- delete existing result buffers
+	for _, result_buffer in ipairs(result_buffers) do
+		if vim.api.nvim_buf_is_valid(result_buffer) then
+			vim.api.nvim_buf_delete(result_buffer, { force = true })
+		end
 	end
 
 	for batch_index, batch_summary in ipairs(result.batchSummaries) do

--- a/lua/mssql/query/pretty_print.lua
+++ b/lua/mssql/query/pretty_print.lua
@@ -76,9 +76,7 @@ local function pretty_print(column_headers, rows, max_width)
 		table.insert(lines, row_to_string(row, widths))
 	end
 
-	return table.concat(lines, "\n")
+	return lines
 end
-
-print(pretty_print({ "age", "name" }, { { "bob", 10 }, { "sarah", 64 } }, 100))
 
 return pretty_print

--- a/lua/mssql/query/pretty_print.lua
+++ b/lua/mssql/query/pretty_print.lua
@@ -58,7 +58,7 @@ local function row_to_string(row, widths)
 	return "| " .. table.concat(padded_cells, " | ") .. " |"
 end
 
-local function query_results_to_string(query_results, max_width)
+return function(query_results, max_width)
 	truncate_values(query_results, max_width)
 
 	if not (query_results or query_results[1]) then
@@ -76,5 +76,3 @@ local function query_results_to_string(query_results, max_width)
 
 	return table.concat(lines, "\n")
 end
-
-print(query_results_to_string({ { "name", "age as of last year" }, { "Cassandra", 15 }, { "Bob", 30 } }, 100))

--- a/lua/mssql/utils.lua
+++ b/lua/mssql/utils.lua
@@ -50,11 +50,10 @@ local get_lsp_client = function(owner_uri)
 		bufnr = vim.iter(ipairs(vim.api.nvim_list_bufs())):find(function(i, _)
 			return vim.uri_from_fname(vim.api.nvim_buf_get_name(i)) == owner_uri
 		end)
+		safe_assert(bufnr, "No buffer found with filename " .. owner_uri)
 	else
 		bufnr = 0
 	end
-
-	safe_assert(bufnr, "No buffer found with filename " .. owner_uri)
 
 	return safe_assert(
 		vim.lsp.get_clients({ name = "mssql_ls", bufnr = 0 })[1],

--- a/lua/mssql/utils.lua
+++ b/lua/mssql/utils.lua
@@ -47,8 +47,8 @@ local try_resume =
 local get_lsp_client = function(owner_uri)
 	local bufnr
 	if owner_uri then
-		bufnr = vim.iter(ipairs(vim.api.nvim_list_bufs())):find(function(i, _)
-			return vim.uri_from_fname(vim.api.nvim_buf_get_name(i)) == owner_uri
+		bufnr = vim.iter(vim.api.nvim_list_bufs()):find(function(buf)
+			return vim.uri_from_fname(vim.api.nvim_buf_get_name(buf)) == owner_uri
 		end)
 		safe_assert(bufnr, "No buffer found with filename " .. owner_uri)
 	else

--- a/runtests.lua
+++ b/runtests.lua
@@ -42,6 +42,7 @@ local tests = {
 	-- Due to the internal timeout (see findings.md),
 	-- This test in inconsistent
 	-- require("tests.dbo_completion_spec"),
+	require("tests.execute_query_spec"),
 }
 
 coroutine.resume(coroutine.create(function()

--- a/tests/execute_query_spec.lua
+++ b/tests/execute_query_spec.lua
@@ -1,0 +1,24 @@
+local mssql = require("mssql")
+local utils = require("mssql.utils")
+local test_utils = require("tests.utils")
+
+return {
+	test_name = "Queries should execute and show results",
+	run_test_async = function()
+		local query = "SELECT * from TestDbA.dbo.Person join TestDbB.dbo.Car on Person.ID = Car.PersonId"
+		vim.api.nvim_buf_set_lines(0, 0, -1, false, { query })
+		utils.wait_for_schedule_async()
+		mssql.execute_query()
+
+		local _, err = test_utils.wait_for_handler("query/complete", 30000)
+		if err then
+			error(err.message)
+		end
+
+		test_utils.defer_async(2000)
+
+		local results = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+		assert(results:find("Bob"), "Sql query results do not contain Bob")
+		assert(results:find("Hyundai"), "Sql query results do not contain Hyundai")
+	end,
+}


### PR DESCRIPTION
- Query results are opened in a new buffer for each result set
- Query messages are streamed as notifications
- Format is using markdown tables as it's simple and can provide syntax highlighting 
- Column width and row count are truncated
- Findings and docs