### PR TITLE
Bugfix: Correctly render non standard ascii characters

### DIFF
--- a/.github/workflows/seed.sql
+++ b/.github/workflows/seed.sql
@@ -25,8 +25,8 @@ CREATE TABLE PersonNonAscii
 INSERT INTO PersonNonAscii
   ([Name], Age)
 VALUES
-  ('Bob', 40),
-  (N'Böb', 40),
+  ('Very Long Name', 40),
+  (N'Bøb', 40),
   -- New line
   ('Bob' + CHAR(10), 40),
   -- Zero width space

--- a/.github/workflows/seed.sql
+++ b/.github/workflows/seed.sql
@@ -4,12 +4,47 @@ DROP DATABASE IF EXISTS TestDbB;
 CREATE DATABASE TestDbA;
 GO
 USE TestDbA;
-CREATE TABLE Person (ID INT IDENTITY(1,1) PRIMARY KEY, [Name] NVARCHAR(50), Age INT);
-INSERT INTO Person([Name], Age) VALUES ('Bob', 40), ('Amy', 65);
+CREATE TABLE Person
+(
+  ID INT IDENTITY(1,1) PRIMARY KEY,
+  [Name] NVARCHAR(50),
+  Age INT
+);
+INSERT INTO Person
+  ([Name], Age)
+VALUES
+  ('Bob', 40),
+  ('Amy', 65);
+GO
+CREATE TABLE PersonNonAscii
+(
+  ID INT IDENTITY(1,1) PRIMARY KEY,
+  [Name] NVARCHAR(50),
+  Age INT
+);
+INSERT INTO PersonNonAscii
+  ([Name], Age)
+VALUES
+  ('Bob', 40),
+  (N'Böb', 40),
+  -- New line
+  ('Bob' + CHAR(10), 40),
+  -- Zero width space
+  (N'Bob' + NCHAR(8203) , 40);
 GO
 
 CREATE DATABASE TestDbB;
 GO
 USE TestDbB;
-CREATE TABLE Car (ID INT IDENTITY(1,1) PRIMARY KEY, Make NVARCHAR(50), PersonId INT);
-INSERT INTO Car(Make, PersonId) Values ('Merc', 1), ('Ford', 1), ('Hyundai', 2);
+CREATE TABLE Car
+(
+  ID INT IDENTITY(1,1) PRIMARY KEY,
+  Make NVARCHAR(50),
+  PersonId INT
+);
+INSERT INTO Car
+  (Make, PersonId)
+Values
+  ('Merc', 1),
+  ('Ford', 1),
+  ('Hyundai', 2);

--- a/runtests.lua
+++ b/runtests.lua
@@ -47,6 +47,7 @@ local tests = {
 	require("tests.switch_database_spec"),
 	require("tests.query_zero_rows_spec"),
 	require("tests.file_with_space_spec"),
+	require("tests.non_ascii_spec"),
 }
 
 coroutine.resume(coroutine.create(function()

--- a/tests/non_ascii_spec.lua
+++ b/tests/non_ascii_spec.lua
@@ -1,0 +1,27 @@
+local mssql = require("mssql")
+local utils = require("mssql.utils")
+local test_utils = require("tests.utils")
+
+return {
+	test_name = "Non ascii charcters should render properly",
+	run_test_async = function()
+		local query = "select * from TestDbA.dbo.PersonNonAscii"
+		vim.api.nvim_buf_set_lines(0, 0, -1, false, { query })
+		utils.wait_for_schedule_async()
+		mssql.execute_query()
+		local client = vim.lsp.get_clients({ name = "mssql_ls", bufnr = 0 })[1]
+		local buf = vim.api.nvim_get_current_buf()
+
+		local _, err = utils.wait_for_notification_async(buf, client, "query/complete", 30000)
+		if err then
+			error(err.message)
+		end
+
+		test_utils.defer_async(2000)
+
+		local results = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+		-- assert(results:find("Bob"), "Sql query results do not contain Bob")
+		-- assert(results:find("Hyundai"), "Sql query results do not contain Hyundai")
+		vim.cmd("bdelete")
+	end,
+}

--- a/tests/non_ascii_spec.lua
+++ b/tests/non_ascii_spec.lua
@@ -2,6 +2,44 @@ local mssql = require("mssql")
 local utils = require("mssql.utils")
 local test_utils = require("tests.utils")
 
+local function find_pipe_indices(str)
+	local pipe = vim.fn.strgetchar("|", 0)
+
+	local result = {}
+	local running = 0
+	for _, i in ipairs(vim.fn.range(0, vim.fn.strcharlen(str) - 1)) do
+		local unicode = vim.fn.strgetchar(str, i)
+		running = running + vim.fn.strdisplaywidth(vim.fn.nr2char(unicode))
+
+		if unicode == pipe then
+			table.insert(result, running)
+		end
+	end
+	return result
+end
+
+local function all_pipes_same(lines)
+	lines = vim.iter(lines)
+		:map(find_pipe_indices)
+		:filter(function(indicies)
+			return #indicies > 0
+		end)
+		:totable()
+
+	if #lines == 0 then
+		return true
+	end
+
+	local first = lines[1]
+	for _, indicies in ipairs(lines) do
+		if not vim.deep_equal(first, indicies) then
+			return false
+		end
+	end
+
+	return true
+end
+
 return {
 	test_name = "Non ascii charcters should render properly",
 	run_test_async = function()
@@ -19,9 +57,12 @@ return {
 
 		test_utils.defer_async(2000)
 
-		local results = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
-		-- assert(results:find("Bob"), "Sql query results do not contain Bob")
-		-- assert(results:find("Hyundai"), "Sql query results do not contain Hyundai")
+		local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+
+		assert(
+			all_pipes_same(lines),
+			"Not all pipes were in the same position when rendering:\n" .. table.concat(lines, "\n")
+		)
 		vim.cmd("bdelete")
 	end,
 }


### PR DESCRIPTION
Closes #29 and #25 

- Replace new line chars with `\n` (including the backticks) so that it renders nicely in markdown
- Use  `vim.fn.strdisplaywidth` instead of `#str# when computing the length for pretty printing the markdown table
- Tests