### PR TITLE
Add a slash at the start of windows file paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
+        # Getting problems on mac os
+        # os: [ubuntu-latest, macos-latest, windows-latest]
 
     env:
       DbServer: localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload Neovim state folder
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: nvim-state-dump
           path: nvim-state-dump

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     env:
       DbServer: localhost
@@ -42,6 +42,11 @@ jobs:
         run: |
           winget install Neovim.Neovim --silent --accept-package-agreements --accept-source-agreements
           echo "$Env:ProgramFiles\Neovim\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+      - name: Install Neovim (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install neovim
 
       - name: Install Neovim (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,11 @@ jobs:
       - name: Run Neovim tests
         run: |
           nvim -u runtests.lua --headless
+
+      - name: Upload Neovim state folder
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: nvim-state-dump
+          path: nvim-state-dump
+          if-no-files-found: ignore

--- a/findings/notes.md
+++ b/findings/notes.md
@@ -38,7 +38,8 @@ file:///c:/project/readme.md
 
 However it
 [expects the file name to be unescaped](https://github.com/microsoft/sqltoolsservice/blob/d75ef0c6deb44b340fae08cd7633bbbf1e951973/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/LanguageService.cs#L718).
-So just put `file:///` at the start of the path.
+Unix file paths start with a `/`. So just put `file:///` at the start of the
+path, or a double slash if it already has a slash at the start.
 
 ## Timeouts
 

--- a/lua/mssql/utils.lua
+++ b/lua/mssql/utils.lua
@@ -57,9 +57,9 @@ local lsp_file_uri = function(bufnr)
 	local fname = vim.api.nvim_buf_get_name(bufnr)
 	local path = vim.loop.fs_realpath(fname) or fname
 	if vim.loop.os_uname().sysname == "Windows_NT" then
-		path = path:gsub("\\", "/")
+		path = "/" .. path:gsub("\\", "/")
 	end
-	return "file:///" .. path
+	return "file://" .. path
 end
 
 local get_lsp_client = function(owner_uri)

--- a/lua/mssql/utils.lua
+++ b/lua/mssql/utils.lua
@@ -54,10 +54,11 @@ local try_resume =
 
 local lsp_file_uri = function(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
-	local fname = vim.api.nvim_buf_get_name(bufnr)
-	local path = vim.loop.fs_realpath(fname) or fname
-	if vim.loop.os_uname().sysname == "Windows_NT" then
-		path = "/" .. path:gsub("\\", "/")
+	local path = vim.api.nvim_buf_get_name(bufnr)
+	path = vim.fs.normalize(path)
+	path = vim.fs.abspath(path)
+	if vim.uv.os_uname().sysname == "Windows_NT" then
+		path = "/" .. path
 	end
 	return "file://" .. path
 end

--- a/runtests.lua
+++ b/runtests.lua
@@ -20,7 +20,24 @@ vim.opt.rtp:prepend(get_plugin_root())
 vim.opt.swapfile = false
 -- Don't have autocomplete auto insert selections
 vim.o.completeopt = "menu,menuone,noselect,noinsert"
+
+local src = vim.fn.stdpath("state")
+print_without_prompt("nvim state path: " .. src)
 vim.lsp.set_log_level("debug")
+
+local function copy_state_folder()
+	if vim.env.GITHUB_ACTIONS == "true" then
+		local src = vim.fn.stdpath("state")
+		print_without_prompt("nvim state path: " .. src)
+		local dst = "nvim-state-dump"
+
+		if vim.fn.has("win32") == 1 then
+			vim.fn.system({ "xcopy", "/E", "/I", "/Y", src, dst })
+		else
+			vim.fn.system({ "cp", "-r", src, dst })
+		end
+	end
+end
 
 local function run_test(test)
 	print_without_prompt("=== Running: " .. test.test_name .. " ===")
@@ -28,6 +45,7 @@ local function run_test(test)
 
 	if not success then
 		print_without_prompt("\n" .. test.test_name .. " FAILED: " .. err)
+		copy_state_folder()
 		os.exit(1)
 	else
 		print_without_prompt("\nTest passed\n")

--- a/runtests.lua
+++ b/runtests.lua
@@ -42,7 +42,7 @@ local tests = {
 	require("tests.connect_spec"),
 	-- Due to the internal timeout (see findings.md),
 	-- This test in inconsistent
-	-- require("tests.dbo_completion_spec"),
+	require("tests.dbo_completion_spec"),
 	require("tests.execute_query_spec"),
 	require("tests.switch_database_spec"),
 	require("tests.query_zero_rows_spec"),


### PR DESCRIPTION
Closes #14.

Unix file paths start with a /, so the file uri was coming out as file:////home.... So instead prefix it with file:// and just add an extra / at the start of windows paths.