### PR TITLE
Prompt for database

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ You can also use the `lualine_component` in other status lines.
 You can call the following as key maps typing your [prefix](#setup) first, or as
 functions on `require("mssql")`.
 
-| Key map | Function                       | Description                                                                                                                                                      |
-| ------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `n`     | `new_query()`                  | Open a new buffer for sql queries                                                                                                                                |
-| `c`     | `connect()`                    | Connect the current buffer (you'll be prompted to choose a connection)                                                                                           |
-| `x`     | `execute_query()`              | Execute the selection, or the whole buffer                                                                                                                       |
-| `q`     | `disconnect()`                 | Disconnects the current buffer                                                                                                                                   |
-| `s`     | `switch_database()`            | Prompts, then switches to a database that is on the currently connected server                                                                                   |
-| `d`     | `new_default_query()`          | Look for the connection called "default", prompt to choose a database in that server, connect to that database and open a new buffer for querying (very useful!) |
-| `r`     | `refresh_intellisense_cache()` | Rebuild the intellisense cache                                                                                                                                   |
-| `e`     | `edit_connections()`           | Open the [connections file](#connections-json-file) for editing                                                                                                  |
+| Key map | Function                       | Description                                                                                                                                                                       |
+| ------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `n`     | `new_query()`                  | Open a new buffer for sql queries                                                                                                                                                 |
+| `c`     | `connect()`                    | Connect the current buffer (you'll be prompted to choose a connection)                                                                                                            |
+| `x`     | `execute_query()`              | Execute the selection, or the whole buffer                                                                                                                                        |
+| `q`     | `disconnect()`                 | Disconnects the current buffer                                                                                                                                                    |
+| `s`     | `switch_database()`            | Prompts, then switches to a database that is on the currently connected server                                                                                                    |
+| `d`     | `new_default_query()`          | Opens a new query and connects to the connection called `default` in your `connections.json`. Useful when combined with the `promptForDatabase` option in the `connections.json`. |
+| `r`     | `refresh_intellisense_cache()` | Rebuild the intellisense cache                                                                                                                                                    |
+| `e`     | `edit_connections()`           | Open the [connections file](#connections-json-file) for editing                                                                                                                   |
 
 ## Connections json file
 
@@ -152,15 +152,19 @@ The format is `"connection name": connection object`. Eg:
   "Connection B": {
     "server": "AnotherServer",
     "database": "dbB",
-    "authenticationType": "Integrated"
-  },
-  "Connection C": {
-    "connectionString": "Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;"
+    "authenticationType": "Integrated",
+    "promptForDatabase": true
   }
 }
 ```
 
-[Full details of the connections json here](docs/Connections-Json.md).
+Each connection object takes
+[standard connection properties](docs/Connections-Json.md). On top of those, you
+can also provide these useful properties:
+
+| Property            | Type   | Description                                                          |
+| ------------------- | ------ | -------------------------------------------------------------------- |
+| `promptForDatabase` | `bool` | After connecting to the server, select which database to connect to. |
 
 ## Options
 

--- a/lua/mssql/init.lua
+++ b/lua/mssql/init.lua
@@ -239,42 +239,6 @@ local function get_connections(opts)
 	return json
 end
 
-local connect_async = function(opts, query_manager)
-	local json = get_connections(opts)
-	if not json then
-		edit_connections(opts)
-		return
-	end
-
-	local con = utils.ui_select_async(vim.tbl_keys(json), { prompt = "Choose connection" })
-	if not con then
-		utils.log_info("No connection chosen")
-		return
-	end
-
-	local connectParams = {
-		connection = {
-			options = json[con],
-		},
-	}
-
-	query_manager.connect_async(connectParams)
-	utils.log_info("Connected")
-end
-
-local function new_query_async()
-	-- The langauge server requires all files to have a file name.
-	-- Vscode names new files "untitled-1" etc so we'll do the same
-	vim.cmd("enew")
-	local buf = vim.api.nvim_get_current_buf()
-	vim.cmd("file untitled-" .. buf .. ".sql")
-	vim.cmd("setfiletype sql")
-	vim.b[buf].is_temp_name = true
-
-	local client = wait_for_on_attach_async(buf, 10000)
-	return buf, client
-end
-
 local function switch_database_async(buf)
 	if buf == nil then
 		buf = vim.api.nvim_get_current_buf()
@@ -310,6 +274,49 @@ local function switch_database_async(buf)
 
 	query_manager.connect_async(connect_params)
 	utils.log_info("Connected")
+end
+
+local connect_async = function(opts, query_manager)
+	local json = get_connections(opts)
+	if not json then
+		edit_connections(opts)
+		return
+	end
+
+	local con_name = utils.ui_select_async(vim.tbl_keys(json), { prompt = "Choose connection" })
+	if not con_name then
+		utils.log_info("No connection chosen")
+		return
+	end
+
+	local con = json[con_name]
+
+	local connectParams = {
+		connection = {
+			options = con,
+		},
+	}
+
+	query_manager.connect_async(connectParams)
+
+	if con.promptForDatabase then
+		switch_database_async()
+	else
+		utils.log_info("Connected")
+	end
+end
+
+local function new_query_async()
+	-- The langauge server requires all files to have a file name.
+	-- Vscode names new files "untitled-1" etc so we'll do the same
+	vim.cmd("enew")
+	local buf = vim.api.nvim_get_current_buf()
+	vim.cmd("file untitled-" .. buf .. ".sql")
+	vim.cmd("setfiletype sql")
+	vim.b[buf].is_temp_name = true
+
+	local client = wait_for_on_attach_async(buf, 10000)
+	return buf, client
 end
 
 local function new_default_query_async(opts)

--- a/lua/mssql/init.lua
+++ b/lua/mssql/init.lua
@@ -344,7 +344,11 @@ local function new_default_query_async(opts)
 
 	query_manager.connect_async(connectParams)
 
-	switch_database_async(buf)
+	if connection.promptForDatabase then
+		switch_database_async(buf)
+	else
+		utils.log_info("Connected")
+	end
 end
 
 local M = {


### PR DESCRIPTION
Closes #38
- Add `promptForDatabase` option to `connections.json`
- `new_default_query()` now doesn't prompt for database unless this property is added to the default connection in the json file
- Docs