### PR TITLE
Adding excluded_databases to opt, so that they can be excluded when switching databases

### DIFF
--- a/lua/mssql/default_opts.lua
+++ b/lua/mssql/default_opts.lua
@@ -65,4 +65,7 @@ return {
 
 	-- Directory to store download tools and internal config options
 	data_dir = vim.fs.joinpath(vim.fn.stdpath("data"), "/mssql.nvim"):gsub("[/\\]+$", ""),
+
+    -- Databases to exclude when selectinga database to connect to.
+    excluded_databases = {},
 }

--- a/lua/mssql/init.lua
+++ b/lua/mssql/init.lua
@@ -429,7 +429,22 @@ local function switch_database_async(buf)
 		error("Could not list databases", 0)
 	end
 
-	local db = utils.ui_select_async(result.databaseNames, { prompt = "Choose database" })
+    local excluded_databases = plugin_opts.excluded_databases or {}
+    local filteredDatabases = vim.tbl_filter(function(item)
+        for _, ex in ipairs(plugin_opts.excluded_databases) do
+            if vim.startswith(ex, "*") then
+                local suffix = ex:sub(2)
+                if item:find(suffix .. "$") then
+                    return false
+                end
+            elseif item == ex then
+                return false
+            end
+        end
+        return true
+    end, result.databaseNames)
+
+	local db = utils.ui_select_async(filteredDatabases, { prompt = "Choose database" })
 	utils.safe_assert(db, "No database chosen")
 
 	-- get the connect params first, because they get set


### PR DESCRIPTION
My work has a lot of databases that are not meant for the development team, so this would be very useful for us. They can be excluded by name or by way of wildcard.