### PR TITLE
Adding the ability to edit the query results window and commit the changes

### DIFF
--- a/lua/mssql/display_query_results.lua
+++ b/lua/mssql/display_query_results.lua
@@ -124,7 +124,12 @@ local function show_result_set_async(column_info, subset_params, opts)
 		"results " .. subset_params.batchIndex + 1 .. "-" .. subset_params.resultSetIndex + 1 .. extension,
 		opts.results_buffer_filetype
 	)
-	vim.b[buf].query_result_info = { subset_params = subset_params }
+	vim.b[buf].query_result_info = { 
+        buf = buf,
+        query_manager = vim.b.query_manager,
+        lines = lines,
+        subset_params = subset_params 
+    }
 	display_markdown(lines, buf)
 	opts.open_results_in(buf)
 end
@@ -146,6 +151,7 @@ local function display_query_results(opts, result)
 					resultSetIndex = result_set_index - 1,
 					rowsStartIndex = 0,
 					rowsCount = math.min(result_set_summary.rowCount, opts.max_rows),
+                    columnInfo = result_set_summary.columnInfo,
 				}
 				-- fetch and show all results at once
 				vim.schedule(function()

--- a/lua/mssql/interface.lua
+++ b/lua/mssql/interface.lua
@@ -121,7 +121,28 @@ return {
 						icon = { icon = "", color = "green" },
 					}
 
-					return { save_result, keymaps.new_query, keymaps.new_default_query, keymaps.edit_connections }
+                    local bufnr = vim.b.query_result_info.buf
+                    local is_modifiable = vim.api.nvim_buf_get_option(bufnr, "modifiable")
+                    local is_readonly   = vim.api.nvim_buf_get_option(bufnr, "readonly")
+                    local commit = {}
+
+                    if is_modifiable or is_readonly then
+                        commit = {
+                            "w",
+                            M.make_buffer_writeable,
+                            desc = "Make Buffer Writeable",
+                            icon = { icon = "󱘫", color = "green" },
+                        }
+                    else
+                        commit = {
+                            "<CR>",
+                            M.commit_changes,
+                            desc = "Commit",
+                            icon = { icon = "󰋊", color = "green" },
+                        }
+                    end
+
+					return { save_result, commit, keymaps.new_query, keymaps.new_default_query, keymaps.edit_connections }
 				else
 					return { keymaps.new_query, keymaps.new_default_query, keymaps.edit_connections }
 				end
@@ -254,3 +275,4 @@ return {
 		end, { nargs = 1, complete = complete })
 	end,
 }
+


### PR DESCRIPTION
Landed in a pretty good place. I had to put buf, the original lines and the query_manager into the query_result_info object. If you can think of a better way, let me know. 

The limitation is that right now it compares the original results buffer lines with the changed buffer lines. That's not gonna work if a given column to be updated has been truncated. I plan to address that in the next PR, I didn't want this to get too big.

Also, it seems the original files used tabs, but I always use spaces, so the formatting looks a bit wonky.