### PR TITLE
feat: support blank/omitted database in connections.json

### DIFF
--- a/lua/mssql/query_manager.lua
+++ b/lua/mssql/query_manager.lua
@@ -58,6 +58,10 @@ return {
 					error("Error in connecting: " .. result.errorMessage, 0)
 				end
 
+                if result and result.connectionSummary then
+                    connect_params.connection.options.database = result.connectionSummary.databaseName
+                    connect_params.connection.options.DatabaseDisplayName = result.connectionSummary.databaseName
+                end
 				state.set_state(states.Connected)
 				last_connect_params = connect_params
 			end,


### PR DESCRIPTION
This emulates VSCodes behavior for connection entries where the database field can be omitted entirely, or simply left as "" in which case will default to "master".

Fixes #94 