### PR TITLE
feat(statusline): query elapsed time and row count

### DIFF
--- a/lua/mssql/default_opts.lua
+++ b/lua/mssql/default_opts.lua
@@ -1,3 +1,9 @@
+---@class IconsOpts
+---@field enabled boolean
+---@field disconnected string?
+---@field server string?
+---@field database string?
+
 return {
 	-- Set up keymaps with this prefix. If which-key is found, this will be a which-key group.
 	keymap_prefix = nil,
@@ -65,4 +71,13 @@ return {
 
 	-- Directory to store download tools and internal config options
 	data_dir = vim.fs.joinpath(vim.fn.stdpath("data"), "/mssql.nvim"):gsub("[/\\]+$", ""),
+
+	-- Configuration for icons in default lualine component
+	---@type IconsOpts
+	icons = {
+		enabled = false,
+		disconnected = "",
+		server = "",
+		database = "",
+	}
 }

--- a/lua/mssql/init.lua
+++ b/lua/mssql/init.lua
@@ -85,6 +85,7 @@ local function enable_lsp(opts)
 				end
 				return result, err
 			end,
+
 			["query/message"] = function(_, result)
 				if not (result or result.message or result.message.message) then
 					return
@@ -92,7 +93,6 @@ local function enable_lsp(opts)
 
 				opts.view_messages_in(result.message.message, result.message.isError)
 			end,
-
 			["connection/connectionchanged"] = function(_, result, _)
 				if not result.ownerUri then
 					return
@@ -127,6 +127,33 @@ local function enable_lsp(opts)
 				end
 				vim.b[bufnr].on_attach_handlers = {}
 			end
+
+      -- add buffer-local handlers for query stats for lualine_component
+      local qm = vim.b[bufnr].query_manager
+      if qm then
+        local buffer_uri = utils.lsp_file_uri(bufnr)
+
+        -- for query stats (elapsed time, rows affected from SELECT queries)
+        -- avoids conflicts with execute_async when registered this way
+        utils.register_lsp_handler(client, "query/complete", function(_, result, _)
+          if not (result and result.ownerUri and result.ownerUri == buffer_uri) then
+            return
+          end
+          if qm.handle_query_complete then
+            qm.handle_query_complete(result)
+          end
+        end)
+
+        -- DML rows affected query stats
+        utils.register_lsp_handler(client, "query/message", function(_, result, _)
+          if not (result and result.ownerUri and result.ownerUri == buffer_uri) then
+            return
+          end
+          if qm.handle_query_message then
+            qm.handle_query_message(result)
+          end
+        end)
+      end
 		end,
 	}
 
@@ -338,6 +365,15 @@ end
 
 local function setup_async(opts)
 	opts = opts or {}
+    -- ensure that we use user's custom icons if configured, but validate are only single character
+    if opts.icons then
+        opts.icons = vim.tbl_deep_extend("force", default_opts.icons, opts.icons)
+        for key, icon in pairs(opts.icons) do
+            if key ~= "enabled" and type(icon) == "string" and vim.fn.strchars(icon) > 1 then
+                utils.log_warn("Icon '" .. key .. "' should be a single character, got: " .. icon)
+            end
+        end
+    end
 	opts = vim.tbl_deep_extend("keep", opts or {}, default_opts)
 	opts.connections_file = opts.connections_file or joinpath(opts.data_dir, "connections.json")
 	set_show_results_option(opts)
@@ -857,30 +893,56 @@ local M = {
 				return
 			end
 			local state = qm.get_state()
+
 			if state == query_manager_module.states.Disconnected then
-				return "Disconnected"
+				local disconnected_icon = plugin_opts.icons.enabled and plugin_opts.icons.disconnected .. " " or ""
+				return disconnected_icon .. "Connect to MSSQL"
 			elseif state == query_manager_module.states.Connecting then
 				return "Connecting..."
-			elseif state == query_manager_module.states.Executing then
-				return "Executing..."
-			elseif state == query_manager_module.states.Connected then
-				local connect_params = qm.get_connect_params()
-				if not (connect_params and connect_params.connection and connect_params.connection.options) then
-					return "Connected"
-				end
-
-				local db = connect_params.connection.options.database
-				local server = connect_params.connection.options.server
-				if not (db or server) then
-					return "Connected"
-				end
-				local caching = ""
-				if show_caching_in_status_line and qm.is_refreshing() then
-					caching = " (Caching database objects...)"
-				end
-
-				return server .. " | " .. db .. caching
 			end
+
+			local status_parts = {}
+			local exec_info = qm.last_execution()
+			local connect_params = qm.get_connect_params()
+
+			local server_db_string = ""
+			if connect_params and connect_params.connection and connect_params.connection.options then
+				local server = connect_params.connection.options.server
+				local db = connect_params.connection.options.database
+				if db and server then
+					local db_icon, server_icon = "", ""
+					if plugin_opts.icons.enabled then
+						server_icon = plugin_opts.icons.server .. " "
+						db_icon = " " .. plugin_opts.icons.database .. " "
+						server_db_string = server_icon .. server .. db_icon .. db
+					else
+						server_db_string = server .. " | " .. db
+					end
+				end
+			end
+
+			if state == query_manager_module.states.Executing then
+				table.insert(status_parts, server_db_string)
+				table.insert(status_parts, "Executing...")
+				if exec_info.elapsed_time then
+					table.insert(status_parts, utils.format_elapsed_time_to_string(exec_info.elapsed_time, false))
+				end
+			else -- Connected state (after completion, cancellation, or idle)
+				if exec_info.rows_affected ~= nil then
+					local rows_text = exec_info.rows_affected == 1 and "row" or "rows"
+					table.insert(status_parts, string.format("%d %s affected", exec_info.rows_affected, rows_text))
+				end
+				if exec_info.elapsed_time and exec_info.elapsed_time > 0 then
+					table.insert(status_parts, utils.format_elapsed_time_to_string(exec_info.elapsed_time, true))
+				end
+				table.insert(status_parts, server_db_string)
+			end
+
+			if show_caching_in_status_line and qm.is_refreshing() then
+				table.insert(status_parts, "(Caching database objects...)")
+			end
+
+			return table.concat(status_parts, "  ")
 		end,
 		cond = function()
 			return vim.b.query_manager ~= nil

--- a/lua/mssql/query_manager.lua
+++ b/lua/mssql/query_manager.lua
@@ -1,3 +1,7 @@
+---@class MssqlExecutionInfo
+---@field rows_affected? number
+---@field elapsed_time? number
+
 local utils = require("mssql.utils")
 local finder = require("mssql.find_object")
 
@@ -31,8 +35,108 @@ return {
 		local state = new_state()
 		local last_connect_params = {}
 		local owner_uri = utils.lsp_file_uri(bufnr)
+		local execution_timer = nil
+		---@type MssqlExecutionInfo
+		local last_execution_info = { rows_affected = nil, elapsed_time = nil }
+		local start_time = 0
 
-		return {
+		--- Stops the timer and calculates the final, precise time from the start time.
+		---@return nil
+		local function stop_execution_timer()
+			if execution_timer then
+				if start_time > 0 then
+					last_execution_info.elapsed_time = (vim.loop.now() - start_time) / 1000
+				end
+
+				execution_timer:stop()
+				execution_timer:close()
+				execution_timer = nil
+				start_time = 0
+				vim.cmd("redrawstatus")
+			end
+		end
+
+		--- Starts a timer that updates the elapsed time every second.
+		---@return nil
+		local function start_execution_timer()
+			last_execution_info.elapsed_time = 0
+			last_execution_info.rows_affected = nil
+			start_time = vim.loop.now()
+
+			execution_timer = vim.loop.new_timer()
+			if execution_timer then
+				execution_timer:start(0, 1000, vim.schedule_wrap(function()
+					if state.get_state() == states.Executing then
+						last_execution_info.elapsed_time = (vim.loop.now() - start_time) / 1000
+						vim.cmd("redrawstatus")
+					else
+						stop_execution_timer()
+					end
+				end))
+			end
+		end
+
+		--- Parses a query/message string to find the number of rows affected.
+		--- NOTE: Relies on the specific "(N rows affected)" format from the LSP.
+		---@param message string
+		---@return nil
+		local function parse_rows_affected_message(message)
+			local row_count = string.match(message, "%((%d+) rows? affected%)")
+			if row_count then
+				last_execution_info.rows_affected = tonumber(row_count)
+			end
+		end
+
+		--- Sets the final query elapsed time and row count from server results.
+		--- Prioritizes DML row counts if they exist, otherwise uses the SELECT row count.
+		---@param final_time number? The precise final execution time in seconds.
+		---@param select_row_count number The row count returned by the SELECT statement.
+		---@return nil
+		local function set_final_execution_stats(final_time, select_row_count)
+			last_execution_info.elapsed_time = final_time
+			if last_execution_info.rows_affected == nil then
+				last_execution_info.rows_affected = select_row_count
+			end
+		end
+
+		--- Handles the 'query/message' notification to parse for `(N rows affected)` in UPDATE,INSERT,DELETE statements
+		---@param message_result table
+		---@return nil
+		local function handle_query_message(message_result)
+			local ok, err = pcall(function()
+					parse_rows_affected_message(message_result.message.message)
+			end)
+			if not ok then
+				utils.log_warn("Failed to parse rows affected: " .. err)
+			end
+		end
+
+		--- Handles the 'query/complete' notification to parse for elapsed time and for SELECT statements rowCount
+		---@param complete_result table
+		---@return nil
+		local function handle_query_complete(complete_result)
+			local batch_summary = complete_result.batchSummaries and complete_result.batchSummaries[#complete_result.batchSummaries]
+			if not batch_summary then
+			  return
+			end
+
+			local elapsed_str = batch_summary.executionElapsed
+			local hours, minutes, seconds = elapsed_str:match("(%d+):(%d+):([%d.]+)")
+			local final_elapsed_time = (tonumber(hours) or 0) * 3600
+			  + (tonumber(minutes) or 0) * 60
+			  + (tonumber(seconds) or 0)
+
+			-- Get total row count for SELECT statements only
+			local total_row_count = 0
+			if batch_summary.resultSetSummaries and #batch_summary.resultSetSummaries > 0 then
+			  total_row_count = batch_summary.resultSetSummaries[#batch_summary.resultSetSummaries].rowCount
+			end
+
+			set_final_execution_stats(final_elapsed_time, total_row_count)
+		end
+
+
+		local qm = {
 			-- the owner uri gets added to the connect_params
 			connect_async = function(connect_params)
 				if state.get_state() ~= states.Disconnected then
@@ -58,10 +162,10 @@ return {
 					error("Error in connecting: " .. result.errorMessage, 0)
 				end
 
-                if result and result.connectionSummary then
-                    connect_params.connection.options.database = result.connectionSummary.databaseName
-                    connect_params.connection.options.DatabaseDisplayName = result.connectionSummary.databaseName
-                end
+				if result and result.connectionSummary then
+					connect_params.connection.options.database = result.connectionSummary.databaseName
+					connect_params.connection.options.DatabaseDisplayName = result.connectionSummary.databaseName
+				end
 				state.set_state(states.Connected)
 				last_connect_params = connect_params
 			end,
@@ -73,6 +177,7 @@ return {
 				utils.lsp_request_async(client, "connection/disconnect", { ownerUri = owner_uri })
 				state.set_state(states.Disconnected)
 				last_connect_params = {}
+				last_execution_info = { rows_affected = nil, elapsed_time = nil }
 			end,
 
 			execute_async = function(query)
@@ -81,10 +186,13 @@ return {
 				end
 				state.set_state(states.Executing)
 
+				start_execution_timer()
+
 				local result, err =
 					utils.lsp_request_async(client, "query/executeString", { query = query, ownerUri = owner_uri })
 
 				if err then
+                    stop_execution_timer()
 					state.set_state(states.Connected)
 					error("Error executing query: " .. err.message, 0)
 				elseif not result then
@@ -95,15 +203,19 @@ return {
 				end
 
 				result, err = utils.wait_for_notification_async(bufnr, client, "query/complete", 360000)
+				stop_execution_timer()
 				state.set_state(states.Connected)
+				vim.cmd("redrawstatus")
 
 				-- handle cancellations that may be requested while waiting
 				if state.get_state() == states.Cancelling then
+					stop_execution_timer()
 					utils.log_info("Query was cancelled.")
 					return
 				end
 
 				if err then
+					stop_execution_timer()
 					error("Could not execute query: " .. vim.inspect(err), 0)
 				elseif not (result or result.batchSummaries) then
 					error("Could not execute query: no results returned", 0)
@@ -160,6 +272,31 @@ return {
 			is_refreshing = function()
 				return finder.is_refreshing(last_connect_params.connection.options)
 			end,
+
+			--- Returns the last execution's info.
+			---@return MssqlExecutionInfo
+			last_execution = function()
+				return last_execution_info
+			end,
+
+			parse_rows_affected_message = parse_rows_affected_message,
+
+			set_final_execution_stats = set_final_execution_stats,
+			handle_query_complete = handle_query_complete,
+			handle_query_message = handle_query_message,
 		}
+
+		-- Add buffer cleanup to handle cases where buffer is deleted during execution
+		vim.api.nvim_buf_attach(bufnr, false, {
+			on_detach = function()
+				if execution_timer and not execution_timer:is_closing() then
+					execution_timer:stop()
+					execution_timer:close()
+					execution_timer = nil
+				end
+			end
+		})
+
+		return qm
 	end,
 }

--- a/lua/mssql/utils.lua
+++ b/lua/mssql/utils.lua
@@ -145,6 +145,33 @@ local function get_rows_async(subset_params)
 	end
 end
 
+--- Formats elapsed time to display string for lualine component.
+---@param raw_time number?
+---@param with_ms? boolean
+---@return string
+local function format_elapsed_time_to_string(raw_time, with_ms)
+	if raw_time == nil then
+		return ""
+	end
+	with_ms = with_ms == nil and true or with_ms
+	local hours = math.floor(raw_time / 3600)
+	local minutes = math.floor((raw_time % 3600) / 60)
+	local seconds = math.floor(raw_time % 60)
+	local time_str
+	if hours == 0 then
+		time_str = string.format("%02d:%02d", minutes, seconds)
+	else
+		time_str = string.format("%02d:%02d:%02d", hours, minutes, seconds)
+	end
+
+	if with_ms then
+		local ms = math.floor((raw_time % 1) * 1000)
+		return string.format("%s.%03d", time_str, ms)
+	else
+		return time_str
+	end
+end
+
 return {
 	contains = contains,
 	wait_for_schedule_async = wait_for_schedule_async,
@@ -217,6 +244,9 @@ return {
 		log(msg, vim.log.levels.ERROR)
 	end,
 	safe_assert = safe_assert,
+
+    -- formats elapsed time for statusline output
+    format_elapsed_time_to_string = format_elapsed_time_to_string,
 
 	get_selected_text = function()
 		local mode = vim.api.nvim_get_mode().mode

--- a/runtests.lua
+++ b/runtests.lua
@@ -69,6 +69,7 @@ local tests = {
 	require("tests.non_ascii_spec"),
 	require("tests.cancel_query_spec"),
 	require("tests.use_query_spec"),
+	require("tests.lualine_component_spec"),
 }
 
 coroutine.resume(coroutine.create(function()

--- a/tests/lualine_component_spec.lua
+++ b/tests/lualine_component_spec.lua
@@ -1,0 +1,89 @@
+local mssql = require("mssql")
+local utils = require("mssql.utils")
+local test_utils = require("tests.utils")
+
+local function get_lualine_status()
+	local lualine_component_func = require("mssql").lualine_component[1]
+	if not lualine_component_func then
+		error("Could not find lualine component function.")
+	end
+	return lualine_component_func()
+end
+
+return {
+	test_name = "Lualine component should display elapsed time and rows affected",
+	run_test_async = function()
+		local qm = vim.b.query_manager
+		if not (qm and qm.get_state() == "connected") then
+			error("Test setup error: Not connected to a database.")
+		end
+
+		-- Test 1: Verify live timer during execution
+		local query_long = "WAITFOR DELAY '00:00:03'; SELECT 1 AS Test;"
+		vim.api.nvim_buf_set_lines(0, 0, -1, false, { query_long })
+		utils.wait_for_schedule_async()
+
+		mssql.execute_query()
+		local client = vim.lsp.get_clients({ name = "mssql_ls", bufnr = 0 })[1]
+		local buf = vim.api.nvim_get_current_buf()
+
+		test_utils.defer_async(2000)
+
+		local status_during_execution = get_lualine_status()
+		if status_during_execution then
+			local elapsed_pattern = "%d?%d?:?%d%d:%d%d$"
+			assert(status_during_execution:find("Executing..."), "Lualine status should contain 'Executing...' during query.")
+			assert(
+				status_during_execution:find(elapsed_pattern),
+				"Lualine status should show elapsed seconds during query. Status was: " .. status_during_execution
+			)
+		end
+
+		local _, err = utils.wait_for_notification_async(buf, client, "query/complete", 30000)
+		if err then
+			error(err.message)
+		end
+		test_utils.defer_async(1000)
+
+		-- Test 2: Verify final elapsed time after completion
+		local status_after_execution = get_lualine_status()
+		if status_after_execution then
+			assert(status_after_execution, "Status after execution should not be nil")
+			assert(
+				status_after_execution:match("00:03.%d+"),
+				"Lualine status should show final elapsed time with milliseconds. Status was: " .. status_after_execution
+			)
+			assert(
+				status_after_execution:find("1 row affected"),
+				"Lualine status should show '1 row affected' for a SELECT query with one row. Status was: "
+					.. status_after_execution
+			)
+		end
+
+		vim.cmd("bdelete!")
+		test_utils.defer_async(500)
+
+		-- Test 3: Verify "rows affected" for an UPDATE statement
+		vim.api.nvim_set_current_buf(buf) -- switch back to query buffer from the results buffer from prior `execute_query()` call
+		local query_update = "SELECT * INTO #test_temp FROM (VALUES (1,2,3), (1,2,3), (4,5,6), (4,5,6)) AS t(a,b,c); UPDATE #test_temp SET a = a + 1 WHERE a >= 4;"
+		vim.api.nvim_buf_set_lines(0, 0, -1, false, { query_update })
+		mssql.execute_query()
+
+		_, err = utils.wait_for_notification_async(buf, client, "query/complete", 30000)
+		if err then
+			error(err.message)
+		end
+		test_utils.defer_async(2000)
+
+		local status_after_update = get_lualine_status()
+		if status_after_update then
+			assert(
+				status_after_update:find("2 rows affected"),
+				"Lualine status should show '2 rows affected' after update. Status was: " .. status_after_update
+			)
+		end
+
+		vim.cmd("bdelete!")
+		vim.api.nvim_set_current_buf(buf)
+	end,
+}


### PR DESCRIPTION
This enhances the statusline component to provide more detailed feedback on query execution.

The previous `lualine_component` is renamed to `statusline_components` and now returns a table of data instead of a simple string. This makes it more flexible for integration with other statusline plugins (e.g., heirline).

The new data includes:
- A live-updating elapsed time during query execution.
- The total elapsed time of the last completed query.
- The number of rows affected by the last query.

This is implemented by adding a `vim.loop` timer to the `query_manager` and parsing "rows affected" from LSP messages.

Includes new E2E test to ensure the timer and row count are captured correctly.

Fixes #66