### PR TITLE
Add check for vim.NIL on successful connection

### DIFF
--- a/lua/mssql/query_manager.lua
+++ b/lua/mssql/query_manager.lua
@@ -53,7 +53,7 @@ return {
 				if err then
 					state.set_state(states.Disconnected)
 					error("Error in connecting: " .. err.message, 0)
-				elseif result and result.errorMessage then
+				elseif result and result.errorMessage and result.errorMessage ~= vim.NIL then
 					state.set_state(states.Disconnected)
 					error("Error in connecting: " .. result.errorMessage, 0)
 				end


### PR DESCRIPTION
It seems like errorMessage returns with vim.NIL. 
I'm not an expert in Lua, but im guessing 
`result.errorMessage` is truthy unless its "null" so vim.NIL results in a error message when its a successful connect. 

I'm not sure if this is new to neovim 0.12 or older, but this one liner solve this. 
@Kurren123, if there is anything missing let me know. 
This is the first time i ever open a pr in lua or neovim

