### PR TITLE
fix: guard against vim.NIL errorMessage in connection/complete handler

### DIFF
--- a/lua/mssql/query_manager.lua
+++ b/lua/mssql/query_manager.lua
@@ -53,7 +53,7 @@ return {
 				if err then
 					state.set_state(states.Disconnected)
 					error("Error in connecting: " .. err.message, 0)
-				elseif result and result.errorMessage then
+				elseif result and result.errorMessage and type(result.errorMessage) == "string" then
 					state.set_state(states.Disconnected)
 					error("Error in connecting: " .. result.errorMessage, 0)
 				end


### PR DESCRIPTION
**Problem**
When connecting to SQL Server, I got the following error:

> Error  20:10:04 notify.error MSSQL ...l/share/nvim/lazy/mssql.nvim/lua/mssql/query_manager.lua:58: attempt to concatenate field 'errorMessage' (a userdata value)

the connection/complete notification from the SQL Tools Service returns errorMessage: null on a successful connection. Neovim decodes JSON null as vim.NIL (a userdata value).

The existing check:

`elseif result and result.errorMessage then`

evaluates as true for vim.NIL, causing the code to enter the error branch and attempt string concatenation on a userdata value, resulting in:

> attempt to concatenate field 'errorMessage' (a userdata value)
This crash occurs even though the connection itself succeeded.

**Fix**
Added a type() guard to ensure the error branch only fires when errorMessage is an actual string:

`elseif result and result.errorMessage and type(result.errorMessage) == "string" then`

Note:
I am not an expert in lua, just sharing what worked for me :-)